### PR TITLE
Allow for empty arrays instead of replacing by null

### DIFF
--- a/src/Annotation/Normalize.php
+++ b/src/Annotation/Normalize.php
@@ -23,6 +23,7 @@ class Normalize extends AbstractAnnotation
         'normalizeCallbackResult' => ['type' => 'boolean'],
         'skipEmpty' => ['type' => 'boolean'],
         'maxDepth' => ['type' => 'integer'],
+        'allowEmptyArray' => ['type' => 'boolean'],
     ];
 
     /** @var string|null */
@@ -45,6 +46,9 @@ class Normalize extends AbstractAnnotation
 
     /** @var string|null */
     protected $type = null;
+
+    /** @var bool */
+    private $allowEmptyArray = false;
 
     public function __construct(array $properties)
     {
@@ -101,5 +105,10 @@ class Normalize extends AbstractAnnotation
     public function getType(): ?string
     {
         return $this->type;
+    }
+
+    public function getAllowEmptyArray(): bool
+    {
+        return $this->allowEmptyArray;
     }
 }

--- a/src/Service/Normalize/PropertyNormalizer.php
+++ b/src/Service/Normalize/PropertyNormalizer.php
@@ -147,7 +147,10 @@ class PropertyNormalizer extends AbstractNormalizer
                 $propertyName = $propertyAnnotation->getName();
             }
 
-            $propertyValue = (is_array($propertyValue) && empty($propertyValue) ? null : $propertyValue);
+            if(is_array($propertyValue) && empty($propertyValue) && !$propertyAnnotation->getAllowEmptyArray()) {
+                $propertyValue = null;
+            }
+
             if (null !== $translationAnnotation) {
                 $propertyValue = $this->translateValue($propertyValue, $translationAnnotation);
             }

--- a/tests/Annotation/NormalizeTest.php
+++ b/tests/Annotation/NormalizeTest.php
@@ -22,6 +22,7 @@ class NormalizeTest extends TestCase
         $this->assertSame($properties['callback'], $normalize->getCallback());
         $this->assertSame($properties['skipEmpty'], $normalize->getSkipEmpty());
         $this->assertSame($properties['maxDepth'], $normalize->getMaxDepth());
+        $this->assertSame($properties['allowEmptyArray'], $normalize->getAllowEmptyArray());
     }
 
     /**
@@ -85,6 +86,7 @@ class NormalizeTest extends TestCase
             'callback' => 'toArray',
             'skipEmpty' => true,
             'maxDepth' => 2,
+            'allowEmptyArray' => false,
         ];
     }
 }


### PR DESCRIPTION
Instead of replacing empty arrays by null, the allowEmptyArray property on annotations will allow for empty arrays to be serialized.