### PR TITLE
Upgrade doctrine/annotations compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-simplexml": "*",
     "ext-libxml": "*",
     "ext-dom": "*",
-    "doctrine/annotations": "~1.13.0",
+    "doctrine/annotations": "^1.13.0",
     "php": ">=7.2",
     "symfony/framework-bundle": "~5.4",
     "symfony/translation": "~5.4",


### PR DESCRIPTION
This PR introduces a wider compatibility for the `doctrine/annnotations` bundle.

- Unit tests are still 🟢 
